### PR TITLE
Add semicolon install_requires packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(
       packages=find_packages(),
       install_requires=[
         'attrs==18.2.0',
-        'pendulum>=1.2.0<2.0.0',
-        'singer-python>=5.12.2<6.0.0',
-        'backoff>=1.3.2<2.0.0',
-        'psycopg2>=2.9.3<3.0.0',
+        'pendulum>=1.2.0,<2.0.0',
+        'singer-python>=5.12.2,<6.0.0',
+        'backoff>=1.3.2,<2.0.0',
+        'psycopg2>=2.9.3,<3.0.0',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',


### PR DESCRIPTION
Avoid wheel.vendored.packaging.requirements.InvalidRequirement: Expected end or semicolon (after version specifier) error with new release from wheel 0.40.0